### PR TITLE
Added the sandwich x-section and WLTP drive cycle

### DIFF
--- a/ecoOptimize.m
+++ b/ecoOptimize.m
@@ -215,6 +215,46 @@ classdef ecoOptimize
           fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]
           CO2u_km_kg=fuelUse_km_kg*CO2Fuel; %[kg/km/kg]
           CO2u=sum(CO2u_km_kg.*model.driveDistTotal.*mass); %[kg]
+        
+        case 'NEDC'
+          % From Hamza:
+          r = 0.15; % Fraction of kinetic energy regained during deceleration, 15%
+          cr = 0.01; % Coefficient of rolling resistance, 0.01
+          g = 9.81; % Gravitation acceleration [m/s^2]
+          
+          % Extract cycle-dependent terms from function:
+          [CA, CR, CD] = drivecycle(usemodel);  
+          
+          % Calculations
+          diffEff=0.42; %[-] differential efficiency (petrol)
+          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
+          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          CO2Fuel=2.31; %[kg/L]
+          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]
+          CO2u_km_kg=fuelUse_km_kg*CO2Fuel; %[kg/km/kg]
+          CO2u=sum(CO2u_km_kg.*model.driveDistTotal.*mass); %[kg]
+          
+
+        case 'WLTP'
+          % From Hamza:
+          r = 0.15; % Fraction of kinetic energy regained during deceleration, 15%
+          cr = 0.01; % Coefficient of rolling resistance, 0.01
+          g = 9.81; % Gravitation acceleration [m/s^2]
+          pwr = 'class3';
+          
+          % Extract cycle-dependent terms from function:
+          [CA, CR, CD] = drivecycle(usemodel,pwr);  
+            
+          % Calculations
+          diffEff=0.42; %[-] differential efficiency (petrol)
+          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
+          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          CO2Fuel=2.31; %[kg/L]
+          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]
+          CO2u_km_kg=fuelUse_km_kg*CO2Fuel; %[kg/km/kg]
+          CO2u=sum(CO2u_km_kg.*model.driveDistTotal.*mass); %[kg]
+          
+          
       end
       % disposal phase
       CO2d_kg=model.CO2Disp; %[kg/kg]
@@ -251,6 +291,44 @@ classdef ecoOptimize
           priceFuel=15; %[SEK/L]
           Costu_km_kg=fuelUse_km_kg*priceFuel; %[SEK/km/kg]
           Costu=sum(Costu_km_kg.*model.driveDistTotal.*mass); %[SEK]  
+          
+        case 'NEDC'
+          % From Hamza:
+          r = 0.15; % Fraction of kinetic energy regained during deceleration, 15%
+          cr = 0.01; % Coefficient of rolling resistance, 0.01
+          g = 9.81; % Gravitation acceleration [m/s^2]
+          
+          % Extract cycle-dependent terms from function:
+          [CA, CR, CD] = drivecycle(usemodel);
+          
+          %Calculations
+          diffEff=0.42; %[-] differential efficiency (petrol)
+          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
+          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]       
+          priceFuel=15; %[SEK/L]
+          Costu_km_kg=fuelUse_km_kg*priceFuel; %[SEK/km/kg]
+          Costu=sum(Costu_km_kg.*model.driveDistTotal.*mass); %[SEK]
+          
+        case 'WLTP'
+          % From Hamza:
+          r = 0.15; % Fraction of kinetic energy regained during deceleration, 15%
+          cr = 0.01; % Coefficient of rolling resistance, 0.01
+          g = 9.81; % Gravitation acceleration [m/s^2]
+          pwr = 'class3';
+          
+          % Extract cycle-dependent terms from function:
+          [CA, CR, CD] = drivecycle(usemodel,pwr);  
+              
+          %Calculations
+          diffEff=0.42; %[-] differential efficiency (petrol)
+          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
+          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]       
+          priceFuel=15; %[SEK/L]
+          Costu_km_kg=fuelUse_km_kg*priceFuel; %[SEK/km/kg]
+          Costu=sum(Costu_km_kg.*model.driveDistTotal.*mass); %[SEK]
+          
       end
       % disposal phase
       Costd=0; %[SEK]

--- a/ecoOptimize.m~
+++ b/ecoOptimize.m~
@@ -60,8 +60,7 @@ classdef ecoOptimize
           
           %For the Sandwich configuration. This is only valid for 3-layer
           %configurations.
-          if numel(model.H)==3
-              d1 = sum(model.H(1:2:3))/2+model.H(2); %Distance between face centroids
+          if size(model.H)==3
               e  = model.Ei(3)*model.H(3)*d1/dot(model.Ei(1:2:3),model.H(1:2:3)); %distance to neutral axis
               sv = [e^2; (0.5*(model.H(1)+model.H(2))-e)^2; (d1-e)^2];
               model.D = sum(model.Ei.*model.H.^3/12) + (model.Ei.*model.H)*sv; %Flexural rigidity, not simplified
@@ -166,15 +165,15 @@ classdef ecoOptimize
                   t=readtable(tabledata);
               case 'WLTP1'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class1';
+                  pwr = 'class 1';
                   t = readtable(tabledata,'Sheet',pwr);
               case 'WLTP2'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class2';
+                  pwr = 'class 2';
                   t = readtable(tabledata,'Sheet',pwr);
               case 'WLTP3'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class3';
+                  pwr = 'class 3';
                   t = readtable(tabledata,'Sheet',pwr);
           end
           
@@ -242,15 +241,15 @@ classdef ecoOptimize
                   t=readtable(tabledata);
               case 'WLTP1'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class1';
+                  pwr = 'class 1';
                   t = readtable(tabledata,'Sheet',pwr);
               case 'WLTP2'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class2';
+                  pwr = 'class 2';
                   t = readtable(tabledata,'Sheet',pwr);
               case 'WLTP3'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class3';
+                  pwr = 'class 3';
                   t = readtable(tabledata,'Sheet',pwr);
           end
           
@@ -309,10 +308,9 @@ classdef ecoOptimize
           %more advanced model based on drive cycle energy
           crr=0.01*0.85; %[-] %coefficient of effective rolling resistance
           diffEff=0.42; %[-] differential efficiency (petrol)
-          r=0.15; % Fraction of kinetic energy regained during deceleration, 15%
-          cr=0.01; % Coefficient of rolling resistance, 0.01
-          g=9.81; % Gravitation acceleration [m/s^2]
-          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          r = 0.15; % Fraction of kinetic energy regained during deceleration, 15%
+          cr = 0.01; % Coefficient of rolling resistance, 0.01
+          g = 9.81; % Gravitation acceleration [m/s^2]
           
           switch usecycle
               case 'NEDC'
@@ -320,15 +318,15 @@ classdef ecoOptimize
                   t=readtable(tabledata);
               case 'WLTP1'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class1';
+                  pwr = 'class 1';
                   t = readtable(tabledata,'Sheet',pwr);
               case 'WLTP2'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class2';
+                  pwr = 'class 2';
                   t = readtable(tabledata,'Sheet',pwr);
               case 'WLTP3'
                   tabledata = 'WLTP.xlsx';
-                  pwr = 'class3';
+                  pwr = 'class 3';
                   t = readtable(tabledata,'Sheet',pwr);
           end
           
@@ -350,16 +348,57 @@ classdef ecoOptimize
           CR=sum(dx); % [m] Rolling resistance constant 
           CD=sum(vel.^3.*dt); %[m^3/s^2] Drag resistance constant
           CA=sum(acc.*vel.*dt); %[m^2/s^2] Inertial resistance constant
-
-          %Energy calculations
-          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
-          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]  
           
-          %Cost calculations
+          
+          
+          
+          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
+          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]       
           priceFuel=15; %[SEK/L]
           Costu_km_kg=fuelUse_km_kg*priceFuel; %[SEK/km/kg]
           Costu=sum(Costu_km_kg.*model.driveDistTotal.*mass); %[SEK]  
-
+          
+          
+          
+          
+        case 'NEDC'
+          % From Hamza:
+          r = 0.15; % Fraction of kinetic energy regained during deceleration, 15%
+          cr = 0.01; % Coefficient of rolling resistance, 0.01
+          g = 9.81; % Gravitation acceleration [m/s^2]
+          
+          % Extract cycle-dependent terms from function:
+          [CA, CR, CD] = drivecycle(usemodel);
+          
+          %Calculations
+          diffEff=0.42; %[-] differential efficiency (petrol)
+          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
+          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]       
+          priceFuel=15; %[SEK/L]
+          Costu_km_kg=fuelUse_km_kg*priceFuel; %[SEK/km/kg]
+          Costu=sum(Costu_km_kg.*model.driveDistTotal.*mass); %[SEK]
+          
+        case 'WLTP'
+          % From Hamza:
+          r = 0.15; % Fraction of kinetic energy regained during deceleration, 15%
+          cr = 0.01; % Coefficient of rolling resistance, 0.01
+          g = 9.81; % Gravitation acceleration [m/s^2]
+          pwr = 'class3';
+          
+          % Extract cycle-dependent terms from function:
+          [CA, CR, CD] = drivecycle(usemodel,pwr);  
+              
+          %Calculations
+          diffEff=0.42; %[-] differential efficiency (petrol)
+          Eu_km_kg=(9.81*crr*CR+CA)/CR*1e3/diffEff; %[J/km/kg]
+          heatValueFuel=43.5*1e6*0.75; %[J/L]
+          fuelUse_km_kg=Eu_km_kg/heatValueFuel; %[L/km/kg]       
+          priceFuel=15; %[SEK/L]
+          Costu_km_kg=fuelUse_km_kg*priceFuel; %[SEK/km/kg]
+          Costu=sum(Costu_km_kg.*model.driveDistTotal.*mass); %[SEK]
+          
       end
       % disposal phase
       Costd=0; %[SEK]
@@ -374,10 +413,10 @@ classdef ecoOptimize
       method=model.solver;
       switch method
         case 'beamEBAna'
-          beam=computeEulerBernoulli(model,model.plotcurves);
+          beam=computeEulerBernoulli(model,1);
           fval(1)=max(abs(beam.w));
         case 'beamTSAna'
-          beam=computeTimoshenko(model,model.plotcurves);
+          beam=computeTimoshenko(model,1);
           fval(1)=max(abs(beam.w));
         case 'beamEBComsol'
           global comsol

--- a/example_ecodesign_beam.m
+++ b/example_ecodesign_beam.m
@@ -1,0 +1,90 @@
+%% Beam example of eco design
+% This code is written with the intention of developing the authors
+% understanding of how the code is structured.
+%
+%
+% Author: Robert Jonsson
+
+
+%% Clear 
+clc
+clear all
+close all
+
+%% Add material data to path
+addpath('.') %Path to material database
+
+%% Add GCMMA algorithm
+addpath('/Users/robertkth/Documents/GitHub/GCMMA-MMA-code-1.5')
+
+%% Add constraint solver
+addpath('/Users/robertkth/Documents/GitHub/beamEB')
+
+%% Import material data
+materialsData = importdata('materialData.mat');
+
+%% Import ecoOptimize functions
+import ecoOptimize.*
+
+%% Iterating over materials
+
+for m = 1:9
+    
+    % Setting up model geometry
+    model = initmodel;
+    
+    % Adding the model material properties
+    model = setModelMaterial(model,materialsData(m));
+    
+    % Extracting the material names
+    names(m) = materialsData(m).info;
+    
+    
+    
+end
+
+
+%% Functions used
+
+function model = initmodel
+% Create and initialize/restore the model for each material.
+
+    model.fmax = [1e-3];
+    model.driveDistTotal = 1e5;
+    model.P = -1e4;
+    model.L = 1;
+    model.B = 0.15*ones(1,3);
+    model.H = 0.05*ones(1,3);
+    
+end
+
+
+function model = setModelMaterial(model,materialsData)
+% Important thing to remember here is that the materialsData input is not
+% the full struct. The input is every "column" from the materialsData
+% struct.
+
+    model.E=materialsData.youngsModulus{1};
+    model.rho=materialsData.density{1};
+    model.EProd=materialsData.productionEnergy{1};
+    model.EDisp=materialsData.disposalEnergy{1};
+    model.EEoL=materialsData.eolEnergy{1};
+    model.CO2Prod=materialsData.productionCO2{1};
+    model.CO2Disp=materialsData.disposalCO2{1};
+    model.CO2EoL=materialsData.eolCO2{1};
+    model.Cost=materialsData.price{1};
+end
+
+function model = computeOptimalVariable(model)
+% Moment of inertia
+    I0=model.B.*model.H.^3/12;
+    d=([0 cumsum(model.H(1:end-1))]+model.H/2-sum(model.H)/2);
+    A=model.B.*model.H;
+    I=I0+A.*d.^2;
+    
+    
+    
+    
+end
+
+

--- a/example_ecodesign_panel.m
+++ b/example_ecodesign_panel.m
@@ -30,7 +30,7 @@ materialsData=importdata('materialData.mat');
 
 %% iterate material alternatives
 i=0;
-for m=[1 4]
+for m=[1:9]
   i=i+1;
   
   %% initiate model of the panel
@@ -42,7 +42,7 @@ for m=[1 4]
   
   %% determine height to fit constraint and the resulting mass
   model=computeOptimalVariable(model);
-  h(i)=model.H;
+  h(i)=sum(model.H(:));
   mass(i)=computeMass(model);
   
   %% compute LCE and LCCO2
@@ -66,11 +66,6 @@ subplot(2,1,2)
 bargraph(struct('title','CO_2','xlabel',{{'Prod','Use','EoL Disp','EoL Pot'}},'ylabel','[tonne]','legend',{names},'values',LCCO2','showtotal',1))
 
 
-
-
-
-
-
 %% FUNCTIONS
 
 %%
@@ -83,6 +78,7 @@ function model=initModel
   model.L=1;
   model.B=1;
   model.H=0.05;
+  
 end
 
 %%
@@ -102,14 +98,15 @@ end
 function model=computeOptimalVariable(model)
 %this function should determine the optimal values for the geometric
 %variable.
-  model.H=abs(model.P*model.L^3/(4*model.E*model.B*model.dmax)).^(1/3);
+  model.H=abs(model.P*model.L^3./(4*model.E*model.B*model.dmax)).^(1/3);
 end
 
 %%
 function mass=computeMass(model)
 %this function should determine the mass of the model based on its
 %geometric dimensions and material density.
-  mass=model.L.*model.B.*model.H.*model.rho;
+  mass=sum(model.L.*model.B.*model.H.*model.rho);
+  
 end
 
 %%

--- a/main_beam.m
+++ b/main_beam.m
@@ -25,8 +25,8 @@ if restart
   clear all
   clear global
   addpath('.') %path to material database [you could pick a different material database]
-  addpath('../GCMMA-MMA-code-1.5') %path to GCMMA MATLAB functions
-  addpath('../beamEB') %path to constraint solver [you could add a different solver]
+  addpath('/Users/robertkth/Documents/GitHub/GCMMA-MMA-code-1.5') %path to GCMMA MATLAB functions
+  addpath('/Users/robertkth/Documents/GitHub/beamEB') %path to constraint solver [you could add a different solver]
   import ecoOptimize.*
   
   %% load material database
@@ -55,7 +55,7 @@ end
 %% run GCMMA
 disp(['Optimizing for: ',model.objfunc])
 gcmma.displive=1;
-% figure(2), clf, gcmma.plotlive=1;
+%figure(2), clf, gcmma.plotlive=1;
 gcmma.maxoutit=20;
 [gcmma,xval]=GCMMA.run(gcmma);
 [f0val,fval]=optFuncs(xval,xnam,false);
@@ -67,10 +67,6 @@ mass=computeMass(model)
 LCE=computeLCE(model)
 LCCO2=computeLCCO2(model)
 LCCost=computeLCCost(model)
-
-
-
-
 
 
 %% FUNCTIONS
@@ -91,6 +87,8 @@ function model=initModelBeam
   model.material={'Steel' 'Al-alloys' 'Steel'};
   model.alpha=[1 1 1];
 end
+
+
 
 %%
 function dispModel(model,fill)

--- a/main_sandwich.m
+++ b/main_sandwich.m
@@ -74,7 +74,7 @@ LCCost=computeLCCost(model)
 
 %%
 function model=initModelSandwich
-  model.objfunc='LCE';
+  model.objfunc='Mass';
   model.fmax=[5e-3];
   model.driveDistTotal=100e3;
   model.solver='beamEBAna';
@@ -97,6 +97,7 @@ H=repmat(model.H,1,N-numel(model.H)+1);
 H0=([0 cumsum(H(1:end-1))]-sum(H)/2);
 B0=-B/2;
 C=colormap;
+figure()
 for i=1:N
   R=rectangle('Position',[B0(i) H0(i) B(i) H(i)]);
   if fill

--- a/main_test.m
+++ b/main_test.m
@@ -58,17 +58,19 @@ function model = initmodelSWBeam %This is used to set up the initial model
 model.objfunc='LCE'; %Objective function
 model.fmax=[5e-3]; %Maximum deflection
 model.driveDistTotal=100e3; %Driving distance of vehicle
-model.solver='beamTSAna'; %Solver used
-model.loadcase='cantilever_pt'; %Load case (pt = point load)
+model.solver='beamTSAna'; %Solver used Euler-Bernoulli (EB) or Timoshenko (TS)
+model.loadcase='simple_pt'; %Load case (pt = point load)
 model.P=-1e4; %Applied load
 model.xP=0.5; %Spanwise fraction of beam where load is applied
 model.L=1; %Beam length
-model.xsection='sandwich'; %Section type
+model.xsection='layered'; %Section type
 model.B=0.3; %Cross-section breadth
 model.H=[0.05 0.05 0.05]; %Beam thicknesses [lower face, core, upper face].
 model.material={'CFRP' 'PVC' 'CFRP'}; %Beam materials 
 model.alpha=[1 1 1]; %Material mixtures.
-model.drivecycle = 'WLTP';
+model.drivemodel = 'physicsbased';
+model.drivecycle = 'WLTP3';
+model.plotcurves = 'on'; %Option to plot displacement curves 
 end
 
 function dispModel(model,fill)

--- a/main_test.m
+++ b/main_test.m
@@ -1,0 +1,92 @@
+% This is an attempt to write an optimisation code for a Sandwich Beam
+% Author: Robert Jonsson
+% Date: 2020-08-25
+
+% Clear workspace
+clear all
+close all
+clc
+
+% Add paths to solvers
+addpath('.') %path to material database [you could pick a different material database]
+addpath('/Users/robertkth/Documents/GitHub/GCMMA-MMA-code-1.5') %path to GCMMA MATLAB functions
+addpath('/Users/robertkth/Documents/GitHub/beamEB') %path to constraint solver [you could add a different solver]
+addpath('/Users/robertkth/Documents/GitHub/Timoshenko') %path to constraint solver [you could add a different solver]
+addpath('/Users/robertkth/Documents/GitHub/DriveCycles') %path to drive cycles, for use phase.
+import ecoOptimize.*
+
+% Import the material data to be worked with
+global materialsData
+materialsData = importdata('materialData.mat');
+
+% Define the model to be worked with
+global model
+model = initmodelSWBeam; %The initial model is defined.
+model=blendMaterials(model,materialsData);
+model=updateDependentVars(model);
+figure(1), clf, dispModel(model,0)
+
+% Define optimisation parameters
+xval=[model.B(1) model.H(1) model.H(2) model.H(3)]';
+xnam={'B(1)' 'H(1)' 'H(2)' 'H(3)'}';
+xmin=[0.05 0.001 0.01 0.001]';
+xmax=[0.3 0.1 0.2 0.1]';
+maxiter=20;
+
+% initiate GCMMA
+gcmma=GCMMA.init(@ecoOptimize.optFuncs,xval,xnam,xmin,xmax);
+
+% run GCMMA
+disp(['Optimizing for: ',model.objfunc])
+gcmma.displive=1;
+%figure(2), clf, gcmma.plotlive=1;
+gcmma.maxoutit=20;
+[gcmma,xval]=GCMMA.run(gcmma);
+[f0val,fval]=optFuncs(xval,xnam,false);
+
+% view results
+figure(2), clf, GCMMA.plotIter(gcmma)
+figure(1), dispModel(model,1)
+mass=computeMass(model)
+LCE=computeLCE(model)
+LCCO2=computeLCCO2(model)
+LCCost=computeLCCost(model)
+
+%% Functions
+
+function model = initmodelSWBeam %This is used to set up the initial model
+model.objfunc='LCE'; %Objective function
+model.fmax=[5e-3]; %Maximum deflection
+model.driveDistTotal=100e3; %Driving distance of vehicle
+model.solver='beamTSAna'; %Solver used
+model.loadcase='cantilever_pt'; %Load case (pt = point load)
+model.P=-1e4; %Applied load
+model.xP=0.5; %Spanwise fraction of beam where load is applied
+model.L=1; %Beam length
+model.xsection='sandwich'; %Section type
+model.B=0.3; %Cross-section breadth
+model.H=[0.05 0.05 0.05]; %Beam thicknesses [lower face, core, upper face].
+model.material={'CFRP' 'PVC' 'CFRP'}; %Beam materials 
+model.alpha=[1 1 1]; %Material mixtures.
+model.drivecycle = 'WLTP';
+end
+
+function dispModel(model,fill)
+N=max([numel(model.B) numel(model.H)]);
+B=repmat(model.B,1,N-numel(model.B)+1);
+H=repmat(model.H,1,N-numel(model.H)+1);
+H0=([0 cumsum(H(1:end-1))]-sum(H)/2);
+B0=-B/2;
+C=colormap;
+for i=1:N
+  R=rectangle('Position',[B0(i) H0(i) B(i) H(i)]);
+  if fill
+    set(R,'Facecolor',C(50*(i-1)+1,:))
+  end
+end
+axis([B0(i)-B(i)/10 B0(i)+B(i)+B(i)/10 H0(i)-H(i)/10 H0(i)+H(i)+H(i)/10])
+axis auto, axis equal
+xlabel('b [m]'), ylabel('h [m]')
+end
+
+

--- a/main_test.m~
+++ b/main_test.m~
@@ -1,0 +1,95 @@
+% This is an attempt to write an optimisation code for a Sandwich Beam
+% Author: Robert Jonsson
+% Date: 2020-08-25
+
+% Clear workspace
+clear all
+close all
+clc
+
+% Add paths to solvers
+addpath('.') %path to material database [you could pick a different material database]
+addpath('/Users/robertkth/Documents/GitHub/GCMMA-MMA-code-1.5') %path to GCMMA MATLAB functions
+addpath('/Users/robertkth/Documents/GitHub/beamEB') %path to constraint solver [you could add a different solver]
+addpath('/Users/robertkth/Documents/GitHub/Timoshenko') %path to constraint solver [you could add a different solver]
+addpath('/Users/robertkth/Documents/GitHub/DriveCycles') %path to drive cycles, for use phase.
+import ecoOptimize.*
+
+% Import the material data to be worked with
+global materialsData
+materialsData = importdata('materialData.mat');
+
+% Define the model to be worked with
+global model
+model = initmodelSWBeam; %The initial model is defined.
+model=blendMaterials(model,materialsData);
+model=updateDependentVars(model);
+figure(1), clf, dispModel(model,0)
+
+% Define optimisation parameters
+xval=[model.B(1) model.H(1) model.H(2) model.H(3)]';
+xnam={'B(1)' 'H(1)' 'H(2)' 'H(3)'}';
+xmin=[0.05 0.001 0.01 0.001]';
+xmax=[0.3 0.1 0.2 0.1]';
+maxiter=20;
+
+% initiate GCMMA
+gcmma=GCMMA.init(@ecoOptimize.optFuncs,xval,xnam,xmin,xmax);
+
+% run GCMMA
+disp(['Optimizing for: ',model.objfunc])
+gcmma.displive=1;
+%figure(2), clf, gcmma.plotlive=1;
+gcmma.maxoutit=20;
+[gcmma,xval]=GCMMA.run(gcmma);
+[f0val,fval]=optFuncs(xval,xnam,false);
+
+% view results
+figure(2), clf, GCMMA.plotIter(gcmma)
+figure(1), dispModel(model,1)
+mass=computeMass(model)
+LCE=computeLCE(model)
+LCCO2=computeLCCO2(model)
+LCCost=computeLCCost(model)
+
+%% Functions
+
+function model = initmodelSWBeam %This is used to set up the initial model
+model.objfunc='LCE'; %Objective function
+model.fmax=[5e-3]; %Maximum deflection
+model.driveDistTotal=100e3; %Driving distance of vehicle
+model.solver='beamTSAna'; %Solver used
+model.loadcase='cantilever_pt'; %Load case (pt = point load)
+model.P=-1e4; %Applied load
+model.xP=0.5; %Spanwise fraction of beam where load is applied
+model.L=1; %Beam length
+model.xsection='sandwich'; %Section type
+model.B=0.3; %Cross-section breadth
+model.H=[0.05 0.05 0.05]; %Beam thicknesses [lower face, core, upper face].
+model.material={'CFRP' 'PVC' 'CFRP'}; %Beam materials 
+model.alpha=[1 1 1]; %Material mixtures.
+model.drivecycle = 'WLTP';
+end
+
+
+
+
+function dispModel(model,fill)
+N=max([numel(model.B) numel(model.H)]);
+B=repmat(model.B,1,N-numel(model.B)+1);
+H=repmat(model.H,1,N-numel(model.H)+1);
+H0=([0 cumsum(H(1:end-1))]-sum(H)/2);
+B0=-B/2;
+C=colormap;
+for i=1:N
+  R=rectangle('Position',[B0(i) H0(i) B(i) H(i)]);
+  if fill
+    set(R,'Facecolor',C(50*(i-1)+1,:))
+  end
+end
+axis([B0(i)-B(i)/10 B0(i)+B(i)+B(i)/10 H0(i)-H(i)/10 H0(i)+H(i)+H(i)/10])
+axis auto, axis equal
+xlabel('b [m]'), ylabel('h [m]')
+end
+
+

--- a/main_test.m~
+++ b/main_test.m~
@@ -58,21 +58,19 @@ function model = initmodelSWBeam %This is used to set up the initial model
 model.objfunc='LCE'; %Objective function
 model.fmax=[5e-3]; %Maximum deflection
 model.driveDistTotal=100e3; %Driving distance of vehicle
-model.solver='beamTSAna'; %Solver used
+model.solver='beamTSAna'; %Solver used Euler-Bernoulli (EB) or Timoshenko (TS)
 model.loadcase='cantilever_pt'; %Load case (pt = point load)
 model.P=-1e4; %Applied load
 model.xP=0.5; %Spanwise fraction of beam where load is applied
 model.L=1; %Beam length
-model.xsection='sandwich'; %Section type
+model.xsection='layered'; %Section type
 model.B=0.3; %Cross-section breadth
 model.H=[0.05 0.05 0.05]; %Beam thicknesses [lower face, core, upper face].
 model.material={'CFRP' 'PVC' 'CFRP'}; %Beam materials 
 model.alpha=[1 1 1]; %Material mixtures.
-model.drivecycle = 'WLTP';
+model.drivemodel = 'physicsbased';
+model.drivecycle = 'WLTP3';
 end
-
-
-
 
 function dispModel(model,fill)
 N=max([numel(model.B) numel(model.H)]);

--- a/main_truss.m
+++ b/main_truss.m
@@ -25,8 +25,8 @@ if restart
   clear all
   clear global
   addpath('.') %path to material database
-  addpath('../GCMMA-MMA-code-1.5') %path to GCMMA MATLAB functions
-  addpath('../trussJVW') %path to constraint solver
+  addpath('/Users/robertkth/Documents/GitHub/GCMMA-MMA-code-1.5') %path to GCMMA MATLAB functions
+  addpath('/Users/robertkth/Documents/GitHub//trussJVW') %path to constraint solver
   import ecoOptimize.*
   
   %% select a material


### PR DESCRIPTION
In ecoOptimze.m I added the 'sandwich' x-section which calculates the flexural rigidity and shear stiffness. The Flexural rigidity is written in a non-simplified form, which means that it covers dissimilar faces too. The shear stiffness however assumes that all shear is carried by the core. 

In ecoOptimize.m I added the WLTP drive cycle. It requires an excel spreadsheet to read data from. This drive cycle covers different Power-to-Weight classes too. 
[WLTP.xlsx](https://github.com/ciore/ecoOptimize/files/5150689/WLTP.xlsx)

Created main_test.m to try the Sandwich-beam load case. 
